### PR TITLE
Add configuration, enable running alongside other server discovery systems, add API

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: Build and test 🏗️
 
-on: [push]
+on: [ push ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -6,10 +6,10 @@ on:
       - main
   # pull_request event is required only for autolabeler
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
   # pull_request_target event is required for autolabeler to support PRs from forks
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   compile-and-deploy-docs:

--- a/.github/workflows/wrapper-validation.yaml
+++ b/.github/workflows/wrapper-validation.yaml
@@ -1,6 +1,6 @@
 name: Gradle Wrapper Validation ✅
 
-on: [pull_request]
+on: [ pull_request ]
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # kryo-server-discovery
+
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kryoniteorg_kryo-server-discovery&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kryoniteorg_kryo-server-discovery)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kryoniteorg_kryo-server-discovery&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kryoniteorg_kryo-server-discovery)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=kryoniteorg_kryo-server-discovery&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=kryoniteorg_kryo-server-discovery)
@@ -11,12 +12,26 @@ The service account in the namespace which the proxy is running in needs the pri
 endpoints from the namespaces where the minecraft servers are running in
 
 ## Setup
-Minecraft servers are discovered by labels. The namespaces where the Minecraft servers are running in have to be
-labeled with `server-discovery: "true"`. The pods which the minecraft server is running in has to be labeled with `server-discovery: "true"`
+
+Servers are discovered by labels. The namespaces where the Minecraft servers are running in, have to be
+labeled with `server-discovery: "true"`. The pods which the minecraft server is running in has to be labeled
+with `server-discovery: "true"`
 as well.
 
-## Examples
+## Configuration
+
+kryo-server-discovery can currently be configured using the following environment variables:
+
+| Variable                            | Default Value | Description                                                                                    |
+|-------------------------------------|---------------|------------------------------------------------------------------------------------------------|
+| `KRYO_SV_ENABLE_JOIN_LISTENER`      | true          | This enables the Join Listener and will send the player to a random discovered server on join. |
+| `KRYO_SV_DISCOVER_TASK_INTERVAL_MS` | 1000          | This is the interval between the times the plugin polls the k8s api to discover new servers.   |
+| `KRYO_SV_SERVER_NAME_FORMAT`        | %s            | Java format string allowing the prefixing or suffixing of the name of the discovered servers.  |
+
+## K8s Examples
+
 Namespace:
+
 ```yaml
 apiVersion: v1
 kind: Namespace
@@ -27,6 +42,7 @@ metadata:
 ```
 
 Deployment:
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -52,7 +68,9 @@ spec:
 ```
 
 ## Role and role bindings
+
 Role in the namespace where the minecraft servers are running in:
+
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -66,6 +84,7 @@ rules:
 ```
 
 Corresponding role binding to the namespace where the proxy is running in:
+
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -83,6 +102,7 @@ roleRef:
 ```
 
 A cluster role has to be defined to list namespaces:
+
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -95,6 +115,7 @@ rules:
 ```
 
 The role binding for the cluster role could look like the following:
+
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -6,15 +6,24 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Timer;
+
+import lombok.extern.slf4j.Slf4j;
 import org.kryonite.kryoserverdiscovery.listener.PlayerJoinListener;
 import org.kryonite.kryoserverdiscovery.serverdiscovery.ServerDiscoveryTask;
 
+@Slf4j
 @Plugin(id = "kryoserverdiscovery", name = "Kryo Server Discovery", version = "1.0.0")
 public class KryoServerDiscoveryPlugin {
 
   private final Timer timer = new Timer(true);
   private final ProxyServer server;
+  private final Map<String, String> configuration = new HashMap<>();
+
+  private final Map<String, String> configurationDefaults = new HashMap<>();
 
   @Inject
   public KryoServerDiscoveryPlugin(ProxyServer server) {
@@ -23,8 +32,42 @@ public class KryoServerDiscoveryPlugin {
 
   @Subscribe
   public void onInitialize(ProxyInitializeEvent event) {
+    this.configurationDefaults.put("enable-join-listener", "true");
+    this.configurationDefaults.put("discovery-task-interval-ms", "1000");
+    this.configurationDefaults.put("server-name-format", "k8s-%s");
+    this.loadEnvironmentConfiguration();
+
+    log.info("Following configuration was parsed:");
+    this.configuration.forEach((k, v) -> log.info(String.format("%s: %s", k, v)));
+
     DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient();
-    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient), 1000, 1000);
-    server.getEventManager().register(this, new PlayerJoinListener(server));
+    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient), 1000, Long.parseLong(this.configuration.get("discovery-task-period-ms")));
+
+    if (Boolean.parseBoolean(this.configuration.get("enable-join-listener"))) {
+      server.getEventManager().register(this, new PlayerJoinListener(server));
+    }
+  }
+
+  public String getConfigEntry(String key) {
+    return this.configuration.get(key);
+  }
+
+  private void loadEnvironmentConfiguration() {
+    Map<String, String> envDirectives = new HashMap<>();
+    System.getenv().entrySet()
+      .stream()
+      .filter(entry -> entry.getKey().startsWith("KRYO_SV_"))
+      .forEach(entry -> {
+        // This transforms the key from the standard environment var format to our configuration directive format
+        // Example: KRYO_SV_ENABLE_JOIN_LISTENER -> enable-join-listener
+        String key = entry.getKey()
+          .replaceFirst("KRYO_SV_", "")
+          .toLowerCase().replace("_", "-");
+        envDirectives.put(key, entry.getValue());
+      });
+
+    this.configurationDefaults
+      .keySet()
+      .forEach(key -> this.configuration.put(key, envDirectives.getOrDefault(key, this.configurationDefaults.get(key))));
   }
 }

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -47,7 +47,7 @@ public class KryoServerDiscoveryPlugin {
     timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient, this.configuration, this.discoveredServers), 1000, Long.parseLong(this.configuration.get("discover-task-interval-ms")));
 
     if (Boolean.parseBoolean(this.configuration.get("enable-join-listener"))) {
-      server.getEventManager().register(this, new PlayerJoinListener(server));
+      server.getEventManager().register(this, new PlayerJoinListener(this, server));
     }
   }
 

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -23,8 +23,13 @@ public class KryoServerDiscoveryPlugin {
   private final ProxyServer server;
   private final Map<String, String> configuration = new HashMap<>();
 
-  private final Map<String, String> configurationDefaults = new HashMap<>();
+  private static final Map<String, String> configurationDefaults = new HashMap<>();
 
+  static {
+    configurationDefaults.put("enable-join-listener", "true");
+    configurationDefaults.put("discover-task-interval-ms", "1000");
+    configurationDefaults.put("server-name-format", "k8s-%s");
+  }
   @Inject
   public KryoServerDiscoveryPlugin(ProxyServer server) {
     this.server = server;
@@ -32,9 +37,7 @@ public class KryoServerDiscoveryPlugin {
 
   @Subscribe
   public void onInitialize(ProxyInitializeEvent event) {
-    this.configurationDefaults.put("enable-join-listener", "true");
-    this.configurationDefaults.put("discover-task-interval-ms", "1000");
-    this.configurationDefaults.put("server-name-format", "k8s-%s");
+
     this.loadConfiguration(System.getenv());
 
     log.info("Following configuration was parsed:");
@@ -52,7 +55,7 @@ public class KryoServerDiscoveryPlugin {
     return this.configuration.get(key);
   }
 
-  private void loadConfiguration(Map<String, String> configuration) {
+  public void loadConfiguration(Map<String, String> configuration) {
     Map<String, String> envDirectives = new HashMap<>();
     configuration.entrySet()
       .stream()
@@ -66,7 +69,7 @@ public class KryoServerDiscoveryPlugin {
         envDirectives.put(key, entry.getValue());
       });
 
-    this.configurationDefaults
+    configurationDefaults
       .keySet()
       .forEach(key -> this.configuration.put(key, envDirectives.getOrDefault(key, this.configurationDefaults.get(key))));
   }

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -41,7 +41,7 @@ public class KryoServerDiscoveryPlugin {
     this.configuration.forEach((k, v) -> log.info(String.format("%s: %s", k, v)));
 
     DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient();
-    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient), 1000, Long.parseLong(this.configuration.get("discovery-task-period-ms")));
+    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient, this), 1000, Long.parseLong(this.configuration.get("discovery-task-period-ms")));
 
     if (Boolean.parseBoolean(this.configuration.get("enable-join-listener"))) {
       server.getEventManager().register(this, new PlayerJoinListener(server));

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -35,7 +35,7 @@ public class KryoServerDiscoveryPlugin {
     this.configurationDefaults.put("enable-join-listener", "true");
     this.configurationDefaults.put("discover-task-interval-ms", "1000");
     this.configurationDefaults.put("server-name-format", "k8s-%s");
-    this.loadEnvironmentConfiguration();
+    this.loadConfiguration(System.getenv());
 
     log.info("Following configuration was parsed:");
     this.configuration.forEach((k, v) -> log.info(String.format("%s: %s", k, v)));
@@ -52,9 +52,9 @@ public class KryoServerDiscoveryPlugin {
     return this.configuration.get(key);
   }
 
-  private void loadEnvironmentConfiguration() {
+  private void loadConfiguration(Map<String, String> configuration) {
     Map<String, String> envDirectives = new HashMap<>();
-    System.getenv().entrySet()
+    configuration.entrySet()
       .stream()
       .filter(entry -> entry.getKey().startsWith("KRYO_SV_"))
       .forEach(entry -> {

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -33,7 +33,7 @@ public class KryoServerDiscoveryPlugin {
   @Subscribe
   public void onInitialize(ProxyInitializeEvent event) {
     this.configurationDefaults.put("enable-join-listener", "true");
-    this.configurationDefaults.put("discovery-task-interval-ms", "1000");
+    this.configurationDefaults.put("discover-task-interval-ms", "1000");
     this.configurationDefaults.put("server-name-format", "k8s-%s");
     this.loadEnvironmentConfiguration();
 
@@ -41,7 +41,7 @@ public class KryoServerDiscoveryPlugin {
     this.configuration.forEach((k, v) -> log.info(String.format("%s: %s", k, v)));
 
     DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient();
-    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient, this), 1000, Long.parseLong(this.configuration.get("discovery-task-interval-ms")));
+    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient, this.configuration), 1000, Long.parseLong(this.configuration.get("discover-task-interval-ms")));
 
     if (Boolean.parseBoolean(this.configuration.get("enable-join-listener"))) {
       server.getEventManager().register(this, new PlayerJoinListener(server));

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -6,14 +6,13 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import lombok.extern.slf4j.Slf4j;
+import org.kryonite.kryoserverdiscovery.listener.PlayerJoinListener;
+import org.kryonite.kryoserverdiscovery.serverdiscovery.ServerDiscoveryTask;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
-
-import lombok.extern.slf4j.Slf4j;
-import org.kryonite.kryoserverdiscovery.listener.PlayerJoinListener;
-import org.kryonite.kryoserverdiscovery.serverdiscovery.ServerDiscoveryTask;
 
 @Slf4j
 @Plugin(id = "kryoserverdiscovery", name = "Kryo Server Discovery", version = "1.0.0")
@@ -30,6 +29,7 @@ public class KryoServerDiscoveryPlugin {
     configurationDefaults.put("discover-task-interval-ms", "1000");
     configurationDefaults.put("server-name-format", "k8s-%s");
   }
+
   @Inject
   public KryoServerDiscoveryPlugin(ProxyServer server) {
     this.server = server;

--- a/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPlugin.java
@@ -41,7 +41,7 @@ public class KryoServerDiscoveryPlugin {
     this.configuration.forEach((k, v) -> log.info(String.format("%s: %s", k, v)));
 
     DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient();
-    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient, this), 1000, Long.parseLong(this.configuration.get("discovery-task-period-ms")));
+    timer.scheduleAtFixedRate(new ServerDiscoveryTask(server, kubernetesClient, this), 1000, Long.parseLong(this.configuration.get("discovery-task-interval-ms")));
 
     if (Boolean.parseBoolean(this.configuration.get("enable-join-listener"))) {
       server.getEventManager().register(this, new PlayerJoinListener(server));

--- a/src/main/java/org/kryonite/kryoserverdiscovery/listener/PlayerJoinListener.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/listener/PlayerJoinListener.java
@@ -3,15 +3,35 @@ package org.kryonite.kryoserverdiscovery.listener;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.player.PlayerChooseInitialServerEvent;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.kryonite.kryoserverdiscovery.KryoServerDiscoveryPlugin;
 
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
 @RequiredArgsConstructor
 public class PlayerJoinListener {
 
+  private final KryoServerDiscoveryPlugin plugin;
   private final ProxyServer proxyServer;
 
   @Subscribe
   public void onPlayerChooseInitialServer(PlayerChooseInitialServerEvent event) {
-    event.setInitialServer(proxyServer.getAllServers().stream().findAny().orElseThrow());
+    Set<String> discoveredServers = this.plugin.getDiscoveredServers();
+    Optional<RegisteredServer> server = proxyServer.getAllServers()
+      .stream()
+      .filter(downstream -> discoveredServers.contains(downstream.getServerInfo().getName()))
+      .findAny();
+
+    if (server.isEmpty()) {
+      log.warn("Join listener could not find a server for player!");
+      return;
+    }
+
+    event.setInitialServer(server.get());
+
   }
 }

--- a/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
@@ -2,16 +2,17 @@ package org.kryonite.kryoserverdiscovery.serverdiscovery;
 
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.kryonite.kryoserverdiscovery.KryoServerDiscoveryPlugin;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -39,7 +40,7 @@ public class ServerDiscoveryTask extends TimerTask {
       proxyServer
         .getAllServers()
         .stream()
-        .filter(server-> discoveredServers.remove(server.getServerInfo().getName()))
+        .filter(server -> discoveredServers.remove(server.getServerInfo().getName()))
         .forEach(server -> proxyServer.unregisterServer(server.getServerInfo()));
 
       serverInfo.forEach(info -> {

--- a/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
@@ -2,20 +2,16 @@ package org.kryonite.kryoserverdiscovery.serverdiscovery;
 
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
-import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceList;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+
 import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kryonite.kryoserverdiscovery.KryoServerDiscoveryPlugin;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -61,11 +57,26 @@ public class ServerDiscoveryTask extends TimerTask {
 
   private Set<ServerInfo> getServerInfo(List<Pod> pods) {
     return pods.stream()
-        .map(pod -> new ServerInfo(
-                pod.getMetadata().getName(),
-                new InetSocketAddress(pod.getStatus().getPodIP(), 25565)
-            )
-        )
-        .collect(Collectors.toSet());
+      .map(pod -> {
+        List<ContainerPort> ports = pod.getSpec()
+          .getContainers()
+          .stream()
+          .map(ct -> ct.getPorts().stream().filter(port -> port.getName().equals("minecraft")).findFirst())
+          .filter(Optional::isPresent)
+          .map(Optional::get)
+          .toList();
+
+        String serverName = pod.getMetadata().getName();
+        // Probably a misconfiguration if there is more than one container with a minecraft port
+        if (ports.size() == 1) {
+          ContainerPort port = ports.get(0);
+          return new ServerInfo(serverName, new InetSocketAddress(pod.getStatus().getPodIP(), port.getHostPort()));
+        }
+
+        log.warn(String.format("None or multiple containers in pod '%s' have a port named 'minecraft', using default port 25565", pod.getMetadata().getName()));
+
+        return new ServerInfo(serverName, new InetSocketAddress(pod.getStatus().getPodIP(), 25565));
+      })
+      .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
@@ -80,7 +80,7 @@ public class ServerDiscoveryTask extends TimerTask {
           .map(Optional::get)
           .toList();
 
-        String serverName = pod.getMetadata().getName();
+        String serverName = String.format(this.plugin.getConfigEntry("server-name-format"), pod.getMetadata().getName());
         // Probably a misconfiguration if there is more than one container with a minecraft port
         if (ports.size() == 1) {
           ContainerPort port = ports.get(0);

--- a/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
@@ -21,7 +21,7 @@ public class ServerDiscoveryTask extends TimerTask {
 
   private final ProxyServer proxyServer;
   private final DefaultKubernetesClient kubernetesClient;
-  private final KryoServerDiscoveryPlugin plugin;
+  private final Map<String, String> configuration;
   private final Set<String> discoveredServers = new HashSet<>();
 
   @Override
@@ -80,7 +80,7 @@ public class ServerDiscoveryTask extends TimerTask {
           .map(Optional::get)
           .toList();
 
-        String serverName = String.format(this.plugin.getConfigEntry("server-name-format"), pod.getMetadata().getName());
+        String serverName = String.format(this.configuration.get("server-name-format"), pod.getMetadata().getName());
         // Probably a misconfiguration if there is more than one container with a minecraft port
         if (ports.size() == 1) {
           ContainerPort port = ports.get(0);

--- a/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
@@ -85,7 +85,7 @@ public class ServerDiscoveryTask extends TimerTask {
         // Probably a misconfiguration if there is more than one container with a minecraft port
         if (ports.size() == 1) {
           ContainerPort port = ports.get(0);
-          return new ServerInfo(serverName, new InetSocketAddress(pod.getStatus().getPodIP(), port.getHostPort()));
+          return new ServerInfo(serverName, new InetSocketAddress(pod.getStatus().getPodIP(), port.getContainerPort()));
         }
 
         log.warn(String.format("None or multiple containers in pod '%s' have a port named 'minecraft', using default port 25565", pod.getMetadata().getName()));

--- a/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
+++ b/src/main/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTask.java
@@ -23,7 +23,7 @@ public class ServerDiscoveryTask extends TimerTask {
   private final ProxyServer proxyServer;
   private final DefaultKubernetesClient kubernetesClient;
   private final Map<String, String> configuration;
-  private final Set<String> discoveredServers = new HashSet<>();
+  private final Set<String> discoveredServers;
 
   @Override
   public void run() {
@@ -72,6 +72,7 @@ public class ServerDiscoveryTask extends TimerTask {
 
   private Set<ServerInfo> getServerInfos(List<Pod> pods) {
     return pods.stream()
+      .filter(pod -> pod.getStatus().getPodIP() != null) // TODO: replace this with a better solution to check if pod is ready
       .map(pod -> {
         List<ContainerPort> ports = pod.getSpec()
           .getContainers()

--- a/src/test/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPluginTest.java
+++ b/src/test/java/org/kryonite/kryoserverdiscovery/KryoServerDiscoveryPluginTest.java
@@ -1,8 +1,5 @@
 package org.kryonite.kryoserverdiscovery;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.junit.jupiter.api.Test;
@@ -12,6 +9,9 @@ import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/org/kryonite/kryoserverdiscovery/config/ConfigurationTest.java
+++ b/src/test/java/org/kryonite/kryoserverdiscovery/config/ConfigurationTest.java
@@ -1,0 +1,32 @@
+package org.kryonite.kryoserverdiscovery.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kryonite.kryoserverdiscovery.KryoServerDiscoveryPlugin;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class ConfigurationTest {
+
+  @InjectMocks
+  private KryoServerDiscoveryPlugin testee;
+
+  @Test
+  void testConfig() {
+    Map<String, String> environmentVariables = new HashMap<>();
+    environmentVariables.put("KRYO_SV_ENABLE_JOIN_LISTENER", "true");
+
+    // Act
+    testee.loadConfiguration(environmentVariables);
+
+    // Assert
+    assertEquals(testee.getConfigEntry("enable-join-listener"), "true");
+
+  }
+}

--- a/src/test/java/org/kryonite/kryoserverdiscovery/listener/PlayerJoinListenerTest.java
+++ b/src/test/java/org/kryonite/kryoserverdiscovery/listener/PlayerJoinListenerTest.java
@@ -1,21 +1,22 @@
 package org.kryonite.kryoserverdiscovery.listener;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.velocitypowered.api.event.player.PlayerChooseInitialServerEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PlayerJoinListenerTest {

--- a/src/test/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTaskTest.java
+++ b/src/test/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTaskTest.java
@@ -1,10 +1,5 @@
 package org.kryonite.kryoserverdiscovery.serverdiscovery;
 
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.velocitypowered.api.proxy.ProxyServer;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceList;
@@ -15,11 +10,6 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -27,6 +17,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ServerDiscoveryTaskTest {
@@ -48,7 +45,6 @@ class ServerDiscoveryTaskTest {
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private MixedOperation<Pod, PodList, PodResource<Pod>> mixedOperationMock;
-
 
 
   static {

--- a/src/test/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTaskTest.java
+++ b/src/test/java/org/kryonite/kryoserverdiscovery/serverdiscovery/ServerDiscoveryTaskTest.java
@@ -15,12 +15,17 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,6 +33,9 @@ class ServerDiscoveryTaskTest {
 
   @InjectMocks
   private ServerDiscoveryTask testee;
+
+  @Spy
+  private static Map<String, String> configuration = new HashMap<>();
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private ProxyServer proxyServerMock;
@@ -42,14 +50,22 @@ class ServerDiscoveryTaskTest {
   private MixedOperation<Pod, PodList, PodResource<Pod>> mixedOperationMock;
 
 
+
+  static {
+    configuration.put("enable-join-listener", "true");
+    configuration.put("discover-task-interval-ms", "1000");
+    configuration.put("server-name-format", "k8s-%s");
+  }
+
   @Test
   void shouldDiscoverServers() {
     // Arrange
-    String expectedName = "testServer";
+    String expectedName = "k8s-testServer";
     String expectedHostName = "192.1.1.1";
 
-    NamespaceList namespaceList = mock(NamespaceList.class, Answers.RETURNS_DEEP_STUBS);
+    String inputName = "testServer";
 
+    NamespaceList namespaceList = mock(NamespaceList.class, Answers.RETURNS_DEEP_STUBS);
     when(kubernetesClientMock.namespaces()).thenReturn(namespaceOperationMock);
     when(namespaceOperationMock.withLabel(ServerDiscoveryTask.LABEL_NAME, "true").list()).thenReturn(namespaceList);
 
@@ -60,12 +76,12 @@ class ServerDiscoveryTaskTest {
 
     when(kubernetesClientMock.pods()).thenReturn(mixedOperationMock);
     when(mixedOperationMock.inNamespace(namespace.getMetadata().getName())
-        .withLabel(ServerDiscoveryTask.LABEL_NAME, "true").list())
-        .thenReturn(podList);
+      .withLabel(ServerDiscoveryTask.LABEL_NAME, "true").list())
+      .thenReturn(podList);
 
     Pod pod = mock(Pod.class, Answers.RETURNS_DEEP_STUBS);
     when(podList.getItems()).thenReturn(List.of(pod));
-    when(pod.getMetadata().getName()).thenReturn(expectedName);
+    when(pod.getMetadata().getName()).thenReturn(inputName);
     when(pod.getStatus().getPodIP()).thenReturn(expectedHostName);
 
     // Act
@@ -73,7 +89,7 @@ class ServerDiscoveryTaskTest {
 
     // Assert
     verify(proxyServerMock).registerServer(
-        argThat(argument -> expectedName.equals(argument.getName())
-            && expectedHostName.equals(argument.getAddress().getHostName())));
+      argThat(argument -> expectedName.equals(argument.getName())
+        && expectedHostName.equals(argument.getAddress().getHostName())));
   }
 }


### PR DESCRIPTION

## Features added

- a way to configure the plugin with environment variables
- a way for other plugins to get a list of server names the plugin has discovered
- a way to change the way servers are named inside velocity

## Fixes

- the plugin now tries to find a container port named 'minecraft' to discover the minecraft port, it falls back to the original behaviour if there is more than one port found in a pod or none are.
- the plugin now does not touch servers it itself hasn't discovered, this includes the server selection in the join listener

